### PR TITLE
[AUG] Add llama gpt option

### DIFF
--- a/src/background/fetch-sse.ts
+++ b/src/background/fetch-sse.ts
@@ -22,16 +22,3 @@ export async function fetchSSE(
     parser.feed(str)
   }
 }
-
-export async function fetchSimple(
-  resource: string,
-  options: RequestInit & { onMessage: (message: string) => void },
-) {
-  const { onMessage, ...fetchOptions } = options
-  const resp = await fetch(resource, fetchOptions)
-  if (!resp.ok) {
-    const error = await resp.json().catch(() => ({}))
-    throw new Error(!isEmpty(error) ? JSON.stringify(error) : `${resp.status} ${resp.statusText}`)
-  }
-  resp.text().then((t) => onMessage(t))
-}

--- a/src/background/fetch-sse.ts
+++ b/src/background/fetch-sse.ts
@@ -22,3 +22,16 @@ export async function fetchSSE(
     parser.feed(str)
   }
 }
+
+export async function fetchSimple(
+  resource: string,
+  options: RequestInit & { onMessage: (message: string) => void },
+) {
+  const { onMessage, ...fetchOptions } = options
+  const resp = await fetch(resource, fetchOptions)
+  if (!resp.ok) {
+    const error = await resp.json().catch(() => ({}))
+    throw new Error(!isEmpty(error) ? JSON.stringify(error) : `${resp.status} ${resp.statusText}`)
+  }
+  resp.text().then((t) => onMessage(t))
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,7 @@
 import Browser from 'webextension-polyfill'
 import { getProviderConfigs, ProviderType } from '../config'
 import { ChatGPTProvider, getChatGPTAccessToken, sendMessageFeedback } from './providers/chatgpt'
+import { LLAMAProvider } from './providers/llama'
 import { OpenAIProvider } from './providers/openai'
 import { Provider } from './types'
 
@@ -19,6 +20,9 @@ async function generateAnswers(
   } else if (providerConfigs.provider === ProviderType.GPT3) {
     const { apiKey, model } = providerConfigs.configs[ProviderType.GPT3]!
     provider = new OpenAIProvider(apiKey, model)
+  } else if (providerConfigs.provider === ProviderType.LLAMA) {
+    const { apiKey, model } = providerConfigs.configs[ProviderType.LLAMA]!
+    provider = new LLAMAProvider(apiKey, model)
   } else {
     throw new Error(`Unknown provider ${providerConfigs.provider}`)
   }
@@ -46,7 +50,6 @@ async function generateAnswers(
 
 Browser.runtime.onConnect.addListener((port) => {
   port.onMessage.addListener(async (msg) => {
-    console.debug('received msg', msg)
     try {
       await generateAnswers(port, msg.question, msg.conversationId, msg.parentMessageId)
     } catch (err: any) {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -50,6 +50,7 @@ async function generateAnswers(
 
 Browser.runtime.onConnect.addListener((port) => {
   port.onMessage.addListener(async (msg) => {
+    console.debug('received msg', msg)
     try {
       await generateAnswers(port, msg.question, msg.conversationId, msg.parentMessageId)
     } catch (err: any) {

--- a/src/background/providers/llama.ts
+++ b/src/background/providers/llama.ts
@@ -1,0 +1,62 @@
+import { fetchSimple } from '../fetch-sse'
+import { GenerateAnswerParams, Provider } from '../types'
+
+export class LLAMAProvider implements Provider {
+  constructor(private token: string, private model: string) {
+    this.token = token
+    this.model = model
+  }
+
+  private buildPrompt(prompt: string): string {
+    return prompt
+  }
+
+  async generateAnswer(params: GenerateAnswerParams) {
+    await fetchSimple('https://api.together.xyz/inference', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.token}`,
+      },
+      body: JSON.stringify({
+        // 'model': 'togethercomputer/llama-2-13b-chat',
+        model: `${this.model}`,
+        max_tokens: 512,
+        prompt: params.prompt,
+        request_type: 'language-model-inference',
+        temperature: 0.7,
+        top_p: 0.7,
+        top_k: 50,
+        repetition_penalty: 1,
+      }),
+      onMessage(message: string) {
+        let data
+        try {
+          data = JSON.parse(message)
+        } catch (err) {
+          console.error(err)
+          return
+        }
+
+        if (data.status != 'finished') {
+          console.error('error status', data.status)
+          return
+        }
+        const text = data.output?.choices?.[0]?.text + '✏'
+        if (text) {
+          // conversationId = data.conversation_id
+          params.onEvent({
+            type: 'answer',
+            data: {
+              text,
+              messageId: '',
+              conversationId: '',
+              parentMessageId: '',
+            },
+          })
+        }
+      },
+    })
+    return {}
+  }
+}

--- a/src/background/providers/llama.ts
+++ b/src/background/providers/llama.ts
@@ -19,7 +19,6 @@ export class LLAMAProvider implements Provider {
         Authorization: `Bearer ${this.token}`,
       },
       body: JSON.stringify({
-        // 'model': 'togethercomputer/llama-2-13b-chat',
         model: `${this.model}`,
         max_tokens: 512,
         prompt: params.prompt,
@@ -44,7 +43,6 @@ export class LLAMAProvider implements Provider {
         }
         const text = data.output?.choices?.[0]?.text + '✏'
         if (text) {
-          // conversationId = data.conversation_id
           params.onEvent({
             type: 'answer',
             data: {

--- a/src/background/providers/llama.ts
+++ b/src/background/providers/llama.ts
@@ -20,7 +20,7 @@ export class LLAMAProvider implements Provider {
       },
       body: JSON.stringify({
         model: `${this.model}`,
-        max_tokens: 512,
+        max_tokens: 2048,
         prompt: params.prompt,
         request_type: 'language-model-inference',
         temperature: 0.7,
@@ -53,6 +53,7 @@ export class LLAMAProvider implements Provider {
             },
           })
         }
+        params.onEvent({ type: 'done' })
       },
     })
     return {}

--- a/src/config.ts
+++ b/src/config.ts
@@ -69,6 +69,7 @@ export async function updateUserConfig(updates: Partial<UserConfig>) {
 export enum ProviderType {
   ChatGPT = 'chatgpt',
   GPT3 = 'gpt3',
+  LLAMA = 'llama',
 }
 
 interface GPT3ProviderConfig {
@@ -80,17 +81,21 @@ export interface ProviderConfigs {
   provider: ProviderType
   configs: {
     [ProviderType.GPT3]: GPT3ProviderConfig | undefined
+    [ProviderType.LLAMA]: GPT3ProviderConfig | undefined
   }
 }
 
 export async function getProviderConfigs(): Promise<ProviderConfigs> {
   const { provider = ProviderType.ChatGPT } = await Browser.storage.local.get('provider')
-  const configKey = `provider:${ProviderType.GPT3}`
-  const result = await Browser.storage.local.get(configKey)
+  const configKeyGPT = `provider:${ProviderType.GPT3}`
+  const configKeyLLAMA = `provider:${ProviderType.LLAMA}`
+  const resultGPT = await Browser.storage.local.get(configKeyGPT)
+  const resultLLAMA = await Browser.storage.local.get(configKeyLLAMA)
   return {
     provider,
     configs: {
-      [ProviderType.GPT3]: result[configKey],
+      [ProviderType.GPT3]: resultGPT[configKeyGPT],
+      [ProviderType.LLAMA]: resultLLAMA[configKeyLLAMA],
     },
   }
 }
@@ -102,5 +107,6 @@ export async function saveProviderConfigs(
   return Browser.storage.local.set({
     provider,
     [`provider:${ProviderType.GPT3}`]: configs[ProviderType.GPT3],
+    [`provider:${ProviderType.LLAMA}`]: configs[ProviderType.LLAMA],
   })
 }

--- a/src/options/ProviderSelect.tsx
+++ b/src/options/ProviderSelect.tsx
@@ -10,8 +10,10 @@ interface ConfigProps {
 }
 
 async function loadModels(): Promise<string[]> {
+  console.log('load models')
   const configs = await fetchExtensionConfigs()
   return configs.openai_model_names
+  // return ['aaaa', 'bbb']
 }
 
 const ConfigPanel: FC<ConfigProps> = ({ config, models }) => {
@@ -19,6 +21,12 @@ const ConfigPanel: FC<ConfigProps> = ({ config, models }) => {
   const { bindings: apiKeyBindings } = useInput(config.configs[ProviderType.GPT3]?.apiKey ?? '')
   const [model, setModel] = useState(config.configs[ProviderType.GPT3]?.model ?? models[0])
   const { setToast } = useToasts()
+  const { bindings: llamaApiModelBindings } = useInput(
+    config.configs[ProviderType.LLAMA]?.model ?? '',
+  )
+  const { bindings: llamaApiKeyBindings } = useInput(
+    config.configs[ProviderType.LLAMA]?.apiKey ?? '',
+  )
 
   const save = useCallback(async () => {
     if (tab === ProviderType.GPT3) {
@@ -31,10 +39,26 @@ const ConfigPanel: FC<ConfigProps> = ({ config, models }) => {
         return
       }
     }
+
+    if (tab === ProviderType.LLAMA) {
+      if (!llamaApiKeyBindings.value) {
+        alert('Please enter your LLAMA API key')
+        return
+      }
+      if (!llamaApiModelBindings) {
+        alert('Please enter your LLAMA model')
+        return
+      }
+    }
+
     await saveProviderConfigs(tab, {
       [ProviderType.GPT3]: {
         model,
         apiKey: apiKeyBindings.value,
+      },
+      [ProviderType.LLAMA]: {
+        model: llamaApiModelBindings.value,
+        apiKey: llamaApiKeyBindings.value,
       },
     })
     setToast({ text: 'Changes saved', type: 'success' })
@@ -74,6 +98,29 @@ const ConfigPanel: FC<ConfigProps> = ({ config, models }) => {
                 target="_blank"
                 rel="noreferrer"
               >
+                here
+              </a>
+            </span>
+          </div>
+        </Tabs.Item>
+        <Tabs.Item label="LLAMA API" value={ProviderType.LLAMA}>
+          <div className="flex flex-col gap-2">
+            <span>
+              LLAMA official API, more stable,{' '}
+              <span className="font-semibold">charge by usage</span>
+            </span>
+            <div className="flex flex-row gap-2">
+              <Input
+                htmlType="username"
+                label="API Model"
+                scale={1 / 3}
+                {...llamaApiModelBindings}
+              />
+              <Input htmlType="password" label="API key" scale={2 / 3} {...llamaApiKeyBindings} />
+            </div>
+            <span className="italic text-xs">
+              You can find or create your API key{' '}
+              <a href="https://api.together.xyz/settings/api-keys" target="_blank" rel="noreferrer">
                 here
               </a>
             </span>

--- a/src/options/ProviderSelect.tsx
+++ b/src/options/ProviderSelect.tsx
@@ -10,10 +10,8 @@ interface ConfigProps {
 }
 
 async function loadModels(): Promise<string[]> {
-  console.log('load models')
   const configs = await fetchExtensionConfigs()
   return configs.openai_model_names
-  // return ['aaaa', 'bbb']
 }
 
 const ConfigPanel: FC<ConfigProps> = ({ config, models }) => {


### PR DESCRIPTION
Config your **model** and **token** to use it.
For example,
<img width="438" alt="Screen Shot 2023-08-22 at 19 18 02" src="https://github.com/hunkimForks/chatgpt-arxiv-extension/assets/13414571/197a99a9-6a0e-4749-96fd-0c794098f21c">


The test model I used is "**togethercomputer/llama-2-13b-chat**".
The token could be found at **API Keys** tab.
<img width="282" alt="Screen Shot 2023-08-22 at 19 16 45" src="https://github.com/hunkimForks/chatgpt-arxiv-extension/assets/13414571/4fb84757-d0e8-4dd5-a3b8-4b8ff9ce01e0">
